### PR TITLE
Document additional required token access

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ TUI - <a href="https://github.com/gizak/termui">termui</a>  </p> <br>
 ```go get -u github.com/irevenko/octotui``` <br>
 ## Token
 To generate token go here: https://github.com/settings/tokens <br>
-Press ```Generate new token``` and select ```user``` field<br>
+Press ```Generate new token``` and select ```repo:status```, ```read:org```, ```read:user```,
+and ```user:email``` fields<br>
 Put this token into ```HOMEDIR/.config/octotui/token```
 
 # Usage 🔬


### PR DESCRIPTION
Per discussion in #2, `repo:status` seems to be necessary to query self.
Also, `read:org` is necessary to query organizations.
