### PR TITLE
Add command to search user by git remote

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"log"
+	"os/exec"
 	"strings"
 
 	gh "github.com/irevenko/octotui/github"
+	help "github.com/irevenko/octotui/helpers"
 
 	tui "github.com/irevenko/octotui/tui"
 	"github.com/spf13/cobra"
@@ -27,6 +30,23 @@ var ByRemote = &cobra.Command{
 	Long:  `octotui by-remote [REMOTE_NAME]`,
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		gitArgs := []string{"remote", "get-url"}
+		gitArgs = append(gitArgs, args...)
+		gitCmd := exec.Command("git", gitArgs...)
+		remoteBytes, err := gitCmd.Output()
+
+		if err != nil {
+			log.Fatalf("failed to get remote URL: %v", err)
+		}
+
+		owner, err := help.OwnerFromRemote(string(remoteBytes))
+
+		if err != nil {
+			log.Fatalf("failed to get owner from remote URL: %v", err)
+		}
+
+		println("owner:", owner)
+
 		panic("Not implemented")
 	},
 }

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -21,6 +21,17 @@ var Search = &cobra.Command{
 	},
 }
 
+var ByRemote = &cobra.Command{
+	Use:   "by-remote",
+	Short: "Get github profile by remote URL",
+	Long:  `octotui by-remote [REMOTE_NAME]`,
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		panic("Not implemented")
+	},
+}
+
 func AddCommands() {
 	RootCmd.AddCommand(Search)
+	RootCmd.AddCommand(ByRemote)
 }

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -44,9 +44,7 @@ var ByRemote = &cobra.Command{
 			log.Fatalf("failed to get owner from remote URL: %v", err)
 		}
 
-		println("owner:", owner)
-
-		panic("Not implemented")
+		Search.Run(cmd, []string{owner})
 	},
 }
 

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -24,14 +24,13 @@ var Search = &cobra.Command{
 	},
 }
 
+var remoteName string
+
 var ByRemote = &cobra.Command{
 	Use:   "by-remote",
 	Short: "Get github profile by remote URL",
-	Long:  `octotui by-remote [REMOTE_NAME]`,
-	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		gitArgs := []string{"remote", "get-url"}
-		gitArgs = append(gitArgs, args...)
+		gitArgs := []string{"remote", "get-url", remoteName}
 		gitCmd := exec.Command("git", gitArgs...)
 		remoteBytes, err := gitCmd.Output()
 
@@ -54,4 +53,14 @@ var ByRemote = &cobra.Command{
 func AddCommands() {
 	RootCmd.AddCommand(Search)
 	RootCmd.AddCommand(ByRemote)
+}
+
+func init() {
+	ByRemote.PersistentFlags().StringVarP(
+		&remoteName,
+		"remote",
+		"r",
+		"origin",
+		"remote containing the user/organization to search",
+	)
 }

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -27,8 +27,8 @@ var Search = &cobra.Command{
 var remoteName string
 
 var ByRemote = &cobra.Command{
-	Use:   "by-remote",
-	Short: "Get github profile by remote URL",
+	Use:   "search-by-remote",
+	Short: "Search for github profile by remote URL",
 	Run: func(cmd *cobra.Command, args []string) {
 		gitArgs := []string{"remote", "get-url", remoteName}
 		gitCmd := exec.Command("git", gitArgs...)

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -26,13 +26,22 @@ var Search = &cobra.Command{
 	},
 }
 
-var remoteName string
+var (
+	remoteName    string
+	repoDirectory string
+)
 
 var ByRemote = &cobra.Command{
 	Use:   "by-remote",
 	Short: "Search for github profile by remote URL",
 	Run: func(cmd *cobra.Command, args []string) {
-		gitArgs := []string{"remote", "get-url", remoteName}
+		gitArgs := []string{
+			"-C",
+			repoDirectory,
+			"remote",
+			"get-url",
+			remoteName,
+		}
 		gitCmd := exec.Command("git", gitArgs...)
 		remoteBytes, err := gitCmd.Output()
 
@@ -80,5 +89,12 @@ func init() {
 		"r",
 		"origin",
 		"remote containing the user/organization to search",
+	)
+	ByRemote.PersistentFlags().StringVarP(
+		&repoDirectory,
+		"repo",
+		"d",
+		".",
+		"directory of the git repository",
 	)
 }

--- a/helpers/remote_parser.go
+++ b/helpers/remote_parser.go
@@ -1,5 +1,24 @@
 package helpers
 
+import (
+	"errors"
+	"regexp"
+)
+
+var githubRegex = regexp.MustCompile(
+	`^(?:(?:git@github\.com:)|(?:https?://github\.com/))([\w\.\-]+)/(?:[\w\.\-]+)\.git$`,
+)
+
+// ErrOwnerNotFound signifies no owner could be found from the remote URL
+var ErrOwnerNotFound error = errors.New("No match found")
+
+// OwnerFromRemote gets the GitHub repo owner from a remote URL
 func OwnerFromRemote(remote string) (owner string, err error) {
+	matches := githubRegex.FindStringSubmatch(remote)
+	if len(matches) > 0 {
+		owner = matches[1]
+	} else {
+		err = ErrOwnerNotFound
+	}
 	return
 }

--- a/helpers/remote_parser.go
+++ b/helpers/remote_parser.go
@@ -6,7 +6,7 @@ import (
 )
 
 var githubRegex = regexp.MustCompile(
-	`^(?:(?:git@github\.com:)|(?:https?://github\.com/))([\w\.\-]+)/(?:[\w\.\-]+)\.git$`,
+	`^(?:(?:git@github\.com:)|(?:https?://github\.com/))([\w\.\-]+)/(?:[\w\.\-]+)\.git\n?$`,
 )
 
 // ErrOwnerNotFound signifies no owner could be found from the remote URL

--- a/helpers/remote_parser.go
+++ b/helpers/remote_parser.go
@@ -1,0 +1,5 @@
+package helpers
+
+func OwnerFromRemote(remote string) (owner string, err error) {
+	return
+}

--- a/helpers/remote_parser_test.go
+++ b/helpers/remote_parser_test.go
@@ -38,6 +38,6 @@ func TestInvalidUrl(t *testing.T) {
 	owner, err := OwnerFromRemote(url)
 
 	if err != ErrOwnerNotFound {
-		t.Fatalf(`OwnerFromRemote(%q) = %q %v, want "irevenko", nil`, url, owner, err)
+		t.Fatalf(`OwnerFromRemote(%q) = %q %v, want "", %v`, url, owner, err, ErrOwnerNotFound)
 	}
 }

--- a/helpers/remote_parser_test.go
+++ b/helpers/remote_parser_test.go
@@ -31,3 +31,13 @@ func TestOwnerBySsh(t *testing.T) {
 		t.Fatalf(`OwnerFromRemote(%q) = %q %v, want "irevenko", nil`, url, owner, err)
 	}
 }
+
+// TestInvalidUrl tests that an invalid URL results in an error.
+func TestInvalidUrl(t *testing.T) {
+	url := "invalid url"
+	owner, err := OwnerFromRemote(url)
+
+	if err != ErrOwnerNotFound {
+		t.Fatalf(`OwnerFromRemote(%q) = %q %v, want "irevenko", nil`, url, owner, err)
+	}
+}

--- a/helpers/remote_parser_test.go
+++ b/helpers/remote_parser_test.go
@@ -1,0 +1,33 @@
+package helpers
+
+import "testing"
+
+// TestOwnerByHttp tests that the proper owner is calculated from an HTTP URL.
+func TestOwnerByHttp(t *testing.T) {
+	url := "http://github.com/irevenko/octostats.git"
+	owner, err := OwnerFromRemote(url)
+
+	if owner != "irevenko" || err != nil {
+		t.Fatalf(`OwnerFromRemote(%q) = %q %v, want "irevenko", nil`, url, owner, err)
+	}
+}
+
+// TestOwnerByHttps tests that the proper owner is calculated from an HTTPS URL.
+func TestOwnerByHttps(t *testing.T) {
+	url := "https://github.com/irevenko/octostats.git"
+	owner, err := OwnerFromRemote(url)
+
+	if owner != "irevenko" || err != nil {
+		t.Fatalf(`OwnerFromRemote(%q) = %q %v, want "irevenko", nil`, url, owner, err)
+	}
+}
+
+// TestOwnerBySsh tests that the proper owner is calculated from an SSH URL.
+func TestOwnerBySsh(t *testing.T) {
+	url := "git@github.com:irevenko/octostats.git"
+	owner, err := OwnerFromRemote(url)
+
+	if owner != "irevenko" || err != nil {
+		t.Fatalf(`OwnerFromRemote(%q) = %q %v, want "irevenko", nil`, url, owner, err)
+	}
+}


### PR DESCRIPTION
This PR adds a command that allows a user to use the git remote URL to get the GitHub username to search. This should save some typing if they want to look up the user stats of an owner of a repo they're working on.

Some example uses:
- `octotui by-remote`: search the username from the `origin` URL
- `octotui by-remote --remote upstream`: search the username from the `upstream` URL
- `octotui by-remote --repo ../other-project`: search the username from the `origin` URL in a different local repository