### PR TITLE
Use init function to add commands

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -21,6 +21,6 @@ var Search = &cobra.Command{
 	},
 }
 
-func AddCommands() {
+func init() {
 	RootCmd.AddCommand(Search)
 }

--- a/main.go
+++ b/main.go
@@ -8,8 +8,6 @@ import (
 )
 
 func main() {
-	cmd.AddCommands()
-
 	if err := cmd.RootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)


### PR DESCRIPTION
This is just a small code refactor for how subcommands are added. Per [cobra's documentation](https://pkg.go.dev/github.com/spf13/cobra#readme-create-additional-commands), subcommands should be added via the `init` function. This slightly simplifies the code by not requiring `AddCommands` to be run in `main`.