### PR TITLE
Add config option for default GitHub user/organization

### DIFF
--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -21,6 +21,6 @@ var Search = &cobra.Command{
 	},
 }
 
-func AddCommands() {
+func init() {
 	RootCmd.AddCommand(Search)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"fmt"
+	"log"
 
 	"github.com/spf13/cobra"
 
@@ -13,6 +13,10 @@ var RootCmd = &cobra.Command{
 	Short: "GitHub stats in your terminal",
 	Long:  `Complete documentation is available at https://github.com/irevenko/octotui`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println(h.LoadOwner())
+		owner := h.LoadOwner()
+
+		if owner == "" {
+			log.Fatalf("Owner is empty. Either add data or use the search subcommand.")
+		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,11 +1,18 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	h "github.com/irevenko/octotui/helpers"
 )
 
 var RootCmd = &cobra.Command{
 	Use:   "octotui",
 	Short: "GitHub stats in your terminal",
 	Long:  `Complete documentation is available at https://github.com/irevenko/octotui`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(h.LoadOwner())
+	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"log"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -17,6 +18,12 @@ var RootCmd = &cobra.Command{
 
 		if owner == "" {
 			log.Fatalf("Owner is empty. Either add data or use the search subcommand.")
+		}
+
+		nameAndType := strings.Split(owner, ":")
+
+		if len(nameAndType) != 2 {
+			log.Fatalf("Default owner must be in format \"name:type\" where type is either %q or %q", h.Org, h.User)
 		}
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,10 +3,14 @@ package cmd
 import (
 	"log"
 	"strings"
+	"time"
 
+	"github.com/briandowns/spinner"
+	ui "github.com/gizak/termui/v3"
 	"github.com/spf13/cobra"
 
 	h "github.com/irevenko/octotui/helpers"
+	tui "github.com/irevenko/octotui/tui"
 )
 
 var RootCmd = &cobra.Command{
@@ -24,6 +28,27 @@ var RootCmd = &cobra.Command{
 
 		if len(nameAndType) != 2 {
 			log.Fatalf("Default owner must be in format \"name:type\" where type is either %q or %q", h.Org, h.User)
+		}
+
+		name := nameAndType[0]
+		ownerType := h.OwnerType(nameAndType[1])
+
+		s := spinner.New(spinner.CharSets[30], 100*time.Millisecond)
+		s.Prefix = "fetching github data "
+		s.FinalMSG = "done"
+		if err := ui.Init(); err != nil {
+			log.Fatalf("failed to initialize termui: %v", err)
+		}
+		defer ui.Close()
+		switch {
+		case ownerType.IsOrg():
+			s.Start()
+			tui.RenderOrganization(name, s)
+		case ownerType.IsUser():
+			s.Start()
+			tui.RenderUser(name, s)
+		default:
+			log.Fatalf("Expected either %q or %q, got %q in default_owner config file", h.Org, h.User, ownerType)
 		}
 	},
 }

--- a/helpers/default_owner.go
+++ b/helpers/default_owner.go
@@ -1,0 +1,32 @@
+package helpers
+
+import (
+	"fmt"
+	"log"
+)
+
+const (
+	ownerFilename = "default_owner"
+)
+
+// OwnerType is the type of owner. Either "user" or "org".
+type OwnerType string
+
+const (
+	org  OwnerType = "org"
+	user OwnerType = "user"
+)
+
+// LoadOwner loads the config file for the default owner.
+func LoadOwner() string {
+	owner, filepath, err := loadConfigFile(ownerFilename)
+
+	if err == errCreatedConfigFile {
+		fmt.Printf("Created owner file in: %v\n", filepath)
+		fmt.Println("Put your owner in this file in the format \"name:type\"")
+		fmt.Printf("Where type is either %q or %q\n", org, user)
+	} else if err != nil {
+		log.Fatalf("Unable to load/create owner file: %v", err)
+	}
+	return owner
+}

--- a/helpers/default_owner.go
+++ b/helpers/default_owner.go
@@ -13,8 +13,10 @@ const (
 type OwnerType string
 
 const (
-	org  OwnerType = "org"
-	user OwnerType = "user"
+	// Org signifies that the owner type is a GitHub organization.
+	Org OwnerType = "org"
+	// User signifies that the owner type is a GitHub user.
+	User OwnerType = "user"
 )
 
 // LoadOwner loads the config file for the default owner.
@@ -24,7 +26,7 @@ func LoadOwner() string {
 	if err == errCreatedConfigFile {
 		fmt.Printf("Created owner file in: %v\n", filepath)
 		fmt.Println("Put your owner in this file in the format \"name:type\"")
-		fmt.Printf("Where type is either %q or %q\n", org, user)
+		fmt.Printf("Where type is either %q or %q\n", Org, User)
 	} else if err != nil {
 		log.Fatalf("Unable to load/create owner file: %v", err)
 	}

--- a/helpers/default_owner.go
+++ b/helpers/default_owner.go
@@ -32,3 +32,13 @@ func LoadOwner() string {
 	}
 	return owner
 }
+
+// IsOrg checks if owner is a GitHub organization.
+func (owner OwnerType) IsOrg() bool {
+	return owner == Org
+}
+
+// IsUser checks if owner is a GitHub user.
+func (owner OwnerType) IsUser() bool {
+	return owner == User
+}

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -27,7 +27,7 @@ func loadConfigFile(filename string) (contents string, createdPath string, err e
 	if _, innerErr := os.Stat(fullFilename); innerErr != nil {
 		if os.IsNotExist(innerErr) {
 			innerErr := os.Mkdir(fullConfigPath, 0755)
-			if innerErr != nil {
+			if innerErr != nil && !os.IsExist(innerErr) {
 				err = fmt.Errorf("Unable to create octotui folder in %v", fullConfigPath)
 				return
 			}

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -1,3 +1,54 @@
 package helpers
 
-const configPath = "/.config/octotui"
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+var configPath = path.Join(".config", "octotui")
+
+var errCreatedConfigFile error = errors.New("File created")
+
+func loadConfigFile(filename string) (contents string, createdPath string, err error) {
+	home, err := os.UserHomeDir()
+
+	if err != nil {
+		err = fmt.Errorf("Unable to get home directory: %w", err)
+		return
+	}
+
+	fullConfigPath := path.Join(home, configPath)
+	fullFilename := path.Join(fullConfigPath, filename)
+
+	if _, innerErr := os.Stat(fullFilename); innerErr != nil {
+		if os.IsNotExist(innerErr) {
+			innerErr := os.Mkdir(fullConfigPath, 0755)
+			if innerErr != nil {
+				err = fmt.Errorf("Unable to create octotui folder in %v", fullConfigPath)
+				return
+			}
+
+			blackListFile, innerErr := os.OpenFile(fullFilename, os.O_RDONLY|os.O_CREATE, 0644)
+			if innerErr != nil {
+				err = fmt.Errorf("Unable to create file %v: %w", fullFilename, innerErr)
+				return
+			}
+			blackListFile.Close()
+
+			createdPath = fullFilename
+			err = errCreatedConfigFile
+			return
+		} else {
+			err = innerErr
+			return
+		}
+	}
+
+	fileContents, err := ioutil.ReadFile(fullFilename)
+	contents = strings.TrimSpace(string(fileContents))
+	return
+}

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -42,10 +42,9 @@ func loadConfigFile(filename string) (contents string, createdPath string, err e
 			createdPath = fullFilename
 			err = errCreatedConfigFile
 			return
-		} else {
-			err = innerErr
-			return
 		}
+		err = innerErr
+		return
 	}
 
 	fileContents, err := ioutil.ReadFile(fullFilename)

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -1,0 +1,3 @@
+package helpers
+
+const configPath = "/.config/octotui"

--- a/helpers/token.go
+++ b/helpers/token.go
@@ -2,44 +2,21 @@ package helpers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
-	"os"
-	"strings"
 )
 
 const (
-	tokenPath = configPath + "/token"
+	tokenFilename = "token"
 )
 
 func LoadToken() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		log.Fatal(err)
+	token, filepath, err := loadConfigFile(tokenFilename)
+
+	if err == errCreatedConfigFile {
+		fmt.Printf("Created token file in: %v\n", filepath)
+		fmt.Println("Put your github token in this file")
+	} else if err != nil {
+		log.Fatalf("Unable to load/create token file: %v", err)
 	}
-
-	if _, err := os.Stat(home + tokenPath); err != nil {
-		if os.IsNotExist(err) {
-			err := os.Mkdir(home+"/.config/octotui", 0755)
-			if err != nil {
-				log.Fatal("Unable to create octotui folder in " + home + "/.config")
-			}
-
-			blackListFile, err := os.OpenFile(home+tokenPath, os.O_RDONLY|os.O_CREATE, 0644)
-			if err != nil {
-				log.Fatal("Unable to create token file in " + home + tokenPath)
-			}
-			blackListFile.Close()
-
-			fmt.Println("Created token file in: " + home + tokenPath)
-			fmt.Println("Put your github token in this file")
-		}
-	}
-
-	token, err := ioutil.ReadFile(home + tokenPath)
-	if err != nil {
-		log.Fatal("Can't read token file in: " + home + tokenPath)
-	}
-
-	return strings.TrimSpace(string(token))
+	return token
 }

--- a/helpers/token.go
+++ b/helpers/token.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	tokenPath = "/.config/octotui/token"
+	tokenPath = configPath + "/token"
 )
 
 func LoadToken() string {

--- a/main.go
+++ b/main.go
@@ -8,8 +8,6 @@ import (
 )
 
 func main() {
-	cmd.AddCommands()
-
 	if err := cmd.RootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/tui/render_stats.go
+++ b/tui/render_stats.go
@@ -27,15 +27,15 @@ func RenderStats(username string, accType string, s *spinner.Spinner) {
 	defer ui.Close()
 
 	if accType == "(user)" {
-		renderUser(username, s)
+		RenderUser(username, s)
 	}
 
 	if accType == "(organization)" {
-		renderOrganization(username, s)
+		RenderOrganization(username, s)
 	}
 }
 
-func renderUser(username string, s *spinner.Spinner) {
+func RenderUser(username string, s *spinner.Spinner) {
 	user, err := g.UserDetails(qlClient, username)
 	if err != nil {
 		log.Fatalf("Couldn't get user details for: %v: %v", username, err)
@@ -80,7 +80,7 @@ func renderUser(username string, s *spinner.Spinner) {
 	}
 }
 
-func renderOrganization(username string, s *spinner.Spinner) {
+func RenderOrganization(username string, s *spinner.Spinner) {
 	org, err := g.OrganizationDetails(qlClient, username)
 	if err != nil {
 		log.Fatalf("Couldn't get org details for: %v: %v", username, err)


### PR DESCRIPTION
This adds a config value in a file called `default_owner`. The config value is in the format `name:type`, where `name` is the user or organization, and `type` is either `user` or `org`. `octotui` will attempt to read from this config file if the `search` subcommand is *not* used. If the config value is not set, then the user is instructed to either fill in this config value or use the `search` subcommand.

Some other changes this PR makes:
- Refactors code so that most of the logic from `LoadToken` is moved into a more generic function `loadConfigFile`
- Fixes bug where `octotui` would fail early if the config *folder* exists, but not the config file
- Made `renderUser` and `renderOrganization` public functions

Resolves #5